### PR TITLE
Use correct dir for PIXI

### DIFF
--- a/@build_baserom.bat
+++ b/@build_baserom.bat
@@ -52,7 +52,7 @@ if "!Action!"=="2" (
 if "!Action!"=="3" (
     echo Inserting custom sprites...
     pushd "%WORKING_DIR%common\"
-    pixi.exe -l common\%PIXI_LIST% !ROMFILE!
+    pixi.exe -l %PIXI_LIST% !ROMFILE!
     echo Done.
 )
 :: Insert custom music with AddmusicK


### PR DESCRIPTION
Hey, I'm going through the batch scripts and trying to port them to Bash because Linux, and I came across this. I'm wasn't able to test if it's actually incorrect, because, well, Linux, but since we're moving into `common` with `pushd`, and there's now `common/common` directory, I'm going to assume this is just a leftover or mistake?

(Edit: Alsooo, wow damn, this is such a cool project thank you for making it! It's really helping me feel less chaotic getting into smw hacking 💓💓)