### PR TITLE
Update README.md

### DIFF
--- a/common/README.md
+++ b/common/README.md
@@ -94,9 +94,7 @@ From the downloaded UberASM ZIP file, copy only the following into the `common` 
 
     list_uberasm.txt
     - a copy of the UberASM list file, where you can specific various patches to be
-     applied to your ROM. 
-    - IMPORTANT: rename '[YOUR ROM]' in this list file to what you named your base 
-    ROM file.
+     applied to your ROM.
 
 ### 5. AddKMusic
 


### PR DESCRIPTION
Since `@build_baserom.bat` uses the command line to reference the rom specifically, `rom: [YOUR ROM]` is no longer in `list_uberasm.txt` and thus this note in the readme is not needed